### PR TITLE
Potential fix for code scanning alert no. 89: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -70,7 +70,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
         res.render('dataErasureResult', {
-          ...req.body
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -85,7 +86,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       }
     } else {
       res.render('dataErasureResult', {
-        ...req.body
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/NavaraLabs/juice-shop/security/code-scanning/89](https://github.com/NavaraLabs/juice-shop/security/code-scanning/89)

To fix the problem, we need to avoid using the entire `req.body` object directly in the template rendering. Instead, we should construct a new object with only the specific properties needed by the template. This ensures that no unexpected or malicious properties from the user-controlled `req.body` object are passed to the template.

1. Identify the specific properties required by the `dataErasureResult` template.
2. Construct a new object with only these properties from `req.body`.
3. Use this new object in the `res.render` calls instead of spreading `req.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
